### PR TITLE
Add Supabase back office, pages, auth, layouts and global styling

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,20 +1,5 @@
-<script setup>
-const user = useSupabaseUser()
-</script>
-
 <template>
-  <div>
-    <h1>🚀 MS IA Academmy</h1>
-    <p v-if="user">Bonjour, {{ user.email }}</p>
-    <p v-else>Bienvenue, connecte-toi pour accéder aux formations</p>
-
-    <nav>
-      <ul>
-        <li><NuxtLink to="/auth">Auth</NuxtLink></li>
-        <li v-if="user"><NuxtLink to="/formations">Formations</NuxtLink></li>
-        <li v-if="user"><NuxtLink to="/upload">Upload</NuxtLink></li>
-        <li v-if="user"><NuxtLink to="/admin">Admin</NuxtLink></li>
-      </ul>
-    </nav>
-  </div>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
 </template>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,155 @@
+:root {
+  color-scheme: light;
+  --color-primary: #7c3aed;
+  --color-primary-dark: #5b21b6;
+  --color-text: #111827;
+  --color-muted: #6b7280;
+  --color-border: #e5e7eb;
+  --color-surface: #ffffff;
+  --color-background: #f8fafc;
+  --color-danger: #dc2626;
+  --shadow-card: 0 20px 45px rgb(15 23 42 / 8%);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--color-background);
+  color: var(--color-text);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.container {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+}
+
+.stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.page-section {
+  padding: 4rem 0;
+}
+
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 24px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow-card);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 44px;
+  border: 0;
+  border-radius: 999px;
+  padding: 0.75rem 1.2rem;
+  background: var(--color-primary);
+  color: white;
+  font-weight: 700;
+  transition: transform 160ms ease, background 160ms ease;
+}
+
+.btn:hover {
+  background: var(--color-primary-dark);
+  transform: translateY(-1px);
+}
+
+.btn.secondary {
+  background: #eef2ff;
+  color: var(--color-primary-dark);
+}
+
+.btn.danger {
+  background: #fee2e2;
+  color: var(--color-danger);
+}
+
+.btn.ghost {
+  background: transparent;
+  color: var(--color-muted);
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.field > span {
+  color: #374151;
+  font-weight: 700;
+}
+
+.field input,
+.field textarea,
+.field select {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  padding: 0.8rem 0.9rem;
+  background: white;
+  color: var(--color-text);
+}
+
+.field textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.alert {
+  border-radius: 16px;
+  padding: 0.85rem 1rem;
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.alert.error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.alert.success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.3rem 0.65rem;
+  background: #ede9fe;
+  color: var(--color-primary-dark);
+  font-size: 0.85rem;
+  font-weight: 700;
+}

--- a/components/FileUploader.vue
+++ b/components/FileUploader.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+const fileName = ref("")
+const message = ref("")
+
+function onFileChange(event: Event) {
+  const input = event.target as HTMLInputElement
+  fileName.value = input.files?.[0]?.name || ""
+  message.value = fileName.value
+    ? `Fichier sélectionné : ${fileName.value}`
+    : "Aucun fichier sélectionné."
+}
+</script>
+
+<template>
+  <div class="card uploader">
+    <label class="field">
+      <span>Ajouter un support de formation</span>
+      <input type="file" @change="onFileChange">
+    </label>
+    <p v-if="message" class="alert success">{{ message }}</p>
+    <p class="hint">Le branchement vers le stockage Supabase pourra être ajouté ici.</p>
+  </div>
+</template>
+
+<style scoped>
+.uploader {
+  display: grid;
+  gap: 1rem;
+}
+
+.hint {
+  margin: 0;
+  color: var(--color-muted);
+}
+</style>

--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -1,0 +1,29 @@
+<template>
+  <footer class="site-footer">
+    <div class="container footer-content">
+      <p>© {{ new Date().getFullYear() }} MS IA Academy. Tous droits réservés.</p>
+      <NuxtLink to="/admin">Back office</NuxtLink>
+    </div>
+  </footer>
+</template>
+
+<style scoped>
+.site-footer {
+  border-top: 1px solid var(--color-border);
+  background: white;
+}
+
+.footer-content {
+  min-height: 92px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--color-muted);
+}
+
+.footer-content a {
+  color: var(--color-primary-dark);
+  font-weight: 700;
+}
+</style>

--- a/components/FormationCard.vue
+++ b/components/FormationCard.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import type { Formation } from "~/composables/useFormations"
+
+defineProps<{ formation: Formation }>()
+</script>
+
+<template>
+  <article class="formation-card card">
+    <div class="formation-card__header">
+      <span class="badge">{{ formation.level || "Tous niveaux" }}</span>
+      <span class="duration">{{ formation.duration || "À la demande" }}</span>
+    </div>
+    <h3>{{ formation.title }}</h3>
+    <p>{{ formation.description || "Description bientôt disponible." }}</p>
+    <NuxtLink class="btn secondary" :to="`/formations/${formation.id}`">Voir la formation</NuxtLink>
+  </article>
+</template>
+
+<style scoped>
+.formation-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.formation-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.formation-card h3,
+.formation-card p {
+  margin: 0;
+}
+
+.formation-card h3 {
+  font-size: 1.35rem;
+}
+
+.formation-card p,
+.duration {
+  color: var(--color-muted);
+}
+</style>

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -1,0 +1,19 @@
+<template>
+  <nav class="inline-nav" aria-label="Navigation rapide">
+    <NuxtLink to="/formations">Formations</NuxtLink>
+    <NuxtLink to="/admin">Back office</NuxtLink>
+  </nav>
+</template>
+
+<style scoped>
+.inline-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.inline-nav a {
+  color: var(--color-primary-dark);
+  font-weight: 700;
+}
+</style>

--- a/composables/useAuth.ts
+++ b/composables/useAuth.ts
@@ -1,0 +1,50 @@
+export function useAuth() {
+  const supabase = useSupabaseClient()
+  const loading = useState("auth:loading", () => false)
+  const errorMessage = useState<string | null>("auth:error", () => null)
+
+  async function signIn(email: string, password: string) {
+    loading.value = true
+    errorMessage.value = null
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    loading.value = false
+
+    if (error) {
+      errorMessage.value = error.message
+      return false
+    }
+
+    await navigateTo("/admin")
+    return true
+  }
+
+  async function signUp(email: string, password: string) {
+    loading.value = true
+    errorMessage.value = null
+    const { error } = await supabase.auth.signUp({ email, password })
+    loading.value = false
+
+    if (error) {
+      errorMessage.value = error.message
+      return false
+    }
+
+    await navigateTo("/admin")
+    return true
+  }
+
+  async function signOut() {
+    loading.value = true
+    await supabase.auth.signOut()
+    loading.value = false
+    await navigateTo("/")
+  }
+
+  return {
+    loading,
+    errorMessage,
+    signIn,
+    signUp,
+    signOut,
+  }
+}

--- a/composables/useFormations.ts
+++ b/composables/useFormations.ts
@@ -1,0 +1,91 @@
+export type Formation = {
+  id: string | number
+  title: string
+  description: string | null
+  level: string | null
+  duration: string | null
+  is_published: boolean
+  created_at?: string
+  updated_at?: string
+}
+
+export type FormationInput = Omit<Formation, "id" | "created_at" | "updated_at">
+
+const TABLE_NAME = "formations"
+
+function normalizeFormation(input: FormationInput): FormationInput {
+  return {
+    title: input.title.trim(),
+    description: input.description?.trim() || null,
+    level: input.level?.trim() || null,
+    duration: input.duration?.trim() || null,
+    is_published: Boolean(input.is_published),
+  }
+}
+
+export function useFormations() {
+  const supabase = useSupabaseClient()
+
+  async function listFormations(options: { onlyPublished?: boolean } = {}) {
+    let query = supabase
+      .from(TABLE_NAME)
+      .select("id,title,description,level,duration,is_published,created_at,updated_at")
+      .order("created_at", { ascending: false })
+
+    if (options.onlyPublished) {
+      query = query.eq("is_published", true)
+    }
+
+    const { data, error } = await query
+    if (error) throw error
+
+    return (data || []) as Formation[]
+  }
+
+  async function getFormation(id: string | number) {
+    const { data, error } = await supabase
+      .from(TABLE_NAME)
+      .select("id,title,description,level,duration,is_published,created_at,updated_at")
+      .eq("id", id)
+      .single()
+
+    if (error) throw error
+    return data as Formation
+  }
+
+  async function createFormation(input: FormationInput) {
+    const { data, error } = await supabase
+      .from(TABLE_NAME)
+      .insert(normalizeFormation(input))
+      .select("id,title,description,level,duration,is_published,created_at,updated_at")
+      .single()
+
+    if (error) throw error
+    return data as Formation
+  }
+
+  async function updateFormation(id: string | number, input: FormationInput) {
+    const { data, error } = await supabase
+      .from(TABLE_NAME)
+      .update(normalizeFormation(input))
+      .eq("id", id)
+      .select("id,title,description,level,duration,is_published,created_at,updated_at")
+      .single()
+
+    if (error) throw error
+    return data as Formation
+  }
+
+  async function deleteFormation(id: string | number) {
+    const { error } = await supabase.from(TABLE_NAME).delete().eq("id", id)
+    if (error) throw error
+  }
+
+  return {
+    listFormations,
+    getFormation,
+    createFormation,
+    updateFormation,
+    deleteFormation,
+  }
+}

--- a/layouts/admin.vue
+++ b/layouts/admin.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+const user = useSupabaseUser()
+const { signOut, loading } = useAuth()
+</script>
+
+<template>
+  <div class="admin-layout">
+    <aside class="admin-sidebar">
+      <NuxtLink to="/" class="admin-brand">MS IA Academy</NuxtLink>
+      <p v-if="user" class="admin-user">{{ user.email }}</p>
+      <nav class="admin-menu" aria-label="Navigation back office">
+        <NuxtLink to="/admin">Tableau de bord</NuxtLink>
+        <NuxtLink to="/formations">Voir le site</NuxtLink>
+      </nav>
+      <button class="btn ghost" :disabled="loading" @click="signOut">Déconnexion</button>
+    </aside>
+
+    <main class="admin-main">
+      <slot />
+    </main>
+  </div>
+</template>
+
+<style scoped>
+.admin-layout {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  background: #f1f5f9;
+}
+
+.admin-sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  border-right: 1px solid var(--color-border);
+  background: #111827;
+  color: white;
+}
+
+.admin-brand {
+  font-size: 1.25rem;
+  font-weight: 900;
+}
+
+.admin-user {
+  margin: 0;
+  color: #cbd5e1;
+  word-break: break-word;
+}
+
+.admin-menu {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.admin-menu a {
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+  color: #e5e7eb;
+  font-weight: 700;
+}
+
+.admin-menu a.router-link-active {
+  background: rgb(255 255 255 / 12%);
+  color: white;
+}
+
+.admin-main {
+  padding: 2rem;
+}
+
+@media (max-width: 860px) {
+  .admin-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-sidebar {
+    position: static;
+    height: auto;
+  }
+}
+</style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+const user = useSupabaseUser()
+const { signOut, loading } = useAuth()
+</script>
+
+<template>
+  <div class="site-shell">
+    <header class="site-header">
+      <div class="container nav-bar">
+        <NuxtLink to="/" class="brand" aria-label="MS IA Academy - Accueil">
+          <span class="brand-mark">MS</span>
+          <span>MS IA Academy</span>
+        </NuxtLink>
+
+        <nav class="nav-links" aria-label="Navigation principale">
+          <NuxtLink to="/formations">Formations</NuxtLink>
+          <NuxtLink v-if="user" to="/admin">Back office</NuxtLink>
+          <NuxtLink v-if="!user" to="/auth" class="btn secondary">Connexion</NuxtLink>
+          <button v-else class="btn ghost" :disabled="loading" @click="signOut">
+            Déconnexion
+          </button>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <slot />
+    </main>
+
+    <Footer />
+  </div>
+</template>
+
+<style scoped>
+.site-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  border-bottom: 1px solid var(--color-border);
+  background: rgb(255 255 255 / 92%);
+  backdrop-filter: blur(18px);
+}
+
+.nav-bar {
+  min-height: 76px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.brand,
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.brand {
+  font-weight: 900;
+  letter-spacing: -0.03em;
+}
+
+.brand-mark {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #7c3aed, #ec4899);
+  color: white;
+}
+
+.nav-links a:not(.btn) {
+  color: var(--color-muted);
+  font-weight: 700;
+}
+
+.nav-links a.router-link-active:not(.btn) {
+  color: var(--color-primary-dark);
+}
+
+main {
+  flex: 1;
+}
+
+@media (max-width: 720px) {
+  .nav-bar,
+  .nav-links {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .nav-bar {
+    padding: 1rem 0;
+  }
+}
+</style>

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -1,0 +1,7 @@
+export default defineNuxtRouteMiddleware(() => {
+  const user = useSupabaseUser()
+
+  if (!user.value) {
+    return navigateTo("/auth")
+  }
+})

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,14 +1,17 @@
 export default defineNuxtConfig({
+  compatibilityDate: "2025-09-19",
+  devtools: { enabled: true },
   modules: ["@nuxtjs/supabase"],
-  
+  css: ["~/assets/css/main.css"],
   runtimeConfig: {
     public: {
-      supabaseUrl: process.env.SUPABASE_URL,
-      supabaseKey: process.env.SUPABASE_KEY,
+      supabaseUrl: process.env.SUPABASE_URL || process.env.NUXT_PUBLIC_SUPABASE_URL,
+      supabaseKey: process.env.SUPABASE_KEY || process.env.NUXT_PUBLIC_SUPABASE_KEY,
     },
   },
-
-  nitro: {
-    compatibilityDate: "2025-09-19", // stabilité build
+  supabase: {
+    redirect: false,
+    url: process.env.SUPABASE_URL || process.env.NUXT_PUBLIC_SUPABASE_URL,
+    key: process.env.SUPABASE_KEY || process.env.NUXT_PUBLIC_SUPABASE_KEY,
   },
 })

--- a/pages/admin.vue
+++ b/pages/admin.vue
@@ -1,0 +1,341 @@
+<script setup lang="ts">
+import type { Formation, FormationInput } from "~/composables/useFormations"
+
+definePageMeta({
+  layout: "admin",
+  middleware: "auth",
+})
+
+const { listFormations, createFormation, updateFormation, deleteFormation } = useFormations()
+const { data: formations, pending, error, refresh } = await useAsyncData(
+  "admin-formations",
+  () => listFormations(),
+)
+
+const emptyForm = (): FormationInput => ({
+  title: "",
+  description: "",
+  level: "Débutant",
+  duration: "",
+  is_published: false,
+})
+
+const form = reactive<FormationInput>(emptyForm())
+const editingId = ref<Formation["id"] | null>(null)
+const saving = ref(false)
+const deletingId = ref<Formation["id"] | null>(null)
+const message = ref("")
+const formError = ref("")
+
+const publishedCount = computed(() => formations.value?.filter((formation) => formation.is_published).length || 0)
+
+function resetForm() {
+  Object.assign(form, emptyForm())
+  editingId.value = null
+  formError.value = ""
+}
+
+function editFormation(formation: Formation) {
+  editingId.value = formation.id
+  Object.assign(form, {
+    title: formation.title,
+    description: formation.description || "",
+    level: formation.level || "Débutant",
+    duration: formation.duration || "",
+    is_published: formation.is_published,
+  })
+  formError.value = ""
+  message.value = ""
+}
+
+async function saveFormation() {
+  if (!form.title.trim()) {
+    formError.value = "Le titre est obligatoire."
+    return
+  }
+
+  saving.value = true
+  formError.value = ""
+  message.value = ""
+
+  try {
+    if (editingId.value) {
+      await updateFormation(editingId.value, form)
+      message.value = "Formation mise à jour."
+    } else {
+      await createFormation(form)
+      message.value = "Formation créée."
+    }
+
+    resetForm()
+    await refresh()
+  } catch (error) {
+    formError.value = error instanceof Error ? error.message : "Impossible d'enregistrer la formation."
+  } finally {
+    saving.value = false
+  }
+}
+
+async function removeFormation(formation: Formation) {
+  if (!window.confirm(`Supprimer définitivement la formation « ${formation.title} » ?`)) {
+    return
+  }
+
+  deletingId.value = formation.id
+  message.value = ""
+  formError.value = ""
+
+  try {
+    await deleteFormation(formation.id)
+    if (editingId.value === formation.id) resetForm()
+    message.value = "Formation supprimée."
+    await refresh()
+  } catch (error) {
+    formError.value = error instanceof Error ? error.message : "Impossible de supprimer la formation."
+  } finally {
+    deletingId.value = null
+  }
+}
+</script>
+
+<template>
+  <section class="admin-page stack">
+    <div class="admin-heading">
+      <div>
+        <span class="badge">Back office</span>
+        <h1>Gestion des formations</h1>
+      </div>
+      <button class="btn secondary" type="button" @click="refresh">Actualiser</button>
+    </div>
+
+    <div class="stats-grid">
+      <div class="card stat-card">
+        <span>Total</span>
+        <strong>{{ formations?.length || 0 }}</strong>
+      </div>
+      <div class="card stat-card">
+        <span>Publiées</span>
+        <strong>{{ publishedCount }}</strong>
+      </div>
+      <div class="card stat-card">
+        <span>Brouillons</span>
+        <strong>{{ (formations?.length || 0) - publishedCount }}</strong>
+      </div>
+    </div>
+
+    <div class="admin-grid">
+      <form class="card form-grid" @submit.prevent="saveFormation">
+        <div class="form-header">
+          <h2>{{ editingId ? "Modifier la formation" : "Créer une formation" }}</h2>
+          <button v-if="editingId" class="btn ghost" type="button" @click="resetForm">Annuler</button>
+        </div>
+
+        <p v-if="message" class="alert success">{{ message }}</p>
+        <p v-if="formError" class="alert error">{{ formError }}</p>
+
+        <label class="field">
+          <span>Titre *</span>
+          <input v-model="form.title" type="text" placeholder="Ex. Automatiser son marketing avec l'IA" required>
+        </label>
+
+        <label class="field">
+          <span>Description</span>
+          <textarea v-model="form.description" placeholder="Objectifs, bénéfices et contenu de la formation" />
+        </label>
+
+        <div class="two-columns">
+          <label class="field">
+            <span>Niveau</span>
+            <select v-model="form.level">
+              <option>Débutant</option>
+              <option>Intermédiaire</option>
+              <option>Avancé</option>
+              <option>Tous niveaux</option>
+            </select>
+          </label>
+
+          <label class="field">
+            <span>Durée</span>
+            <input v-model="form.duration" type="text" placeholder="Ex. 6 semaines">
+          </label>
+        </div>
+
+        <label class="switch-row">
+          <input v-model="form.is_published" type="checkbox">
+          <span>Publier cette formation sur le site</span>
+        </label>
+
+        <button class="btn" type="submit" :disabled="saving">
+          {{ saving ? "Enregistrement..." : editingId ? "Mettre à jour" : "Créer" }}
+        </button>
+      </form>
+
+      <div class="card formations-panel">
+        <div class="form-header">
+          <h2>Catalogue</h2>
+          <NuxtLink class="btn secondary" to="/formations">Voir en ligne</NuxtLink>
+        </div>
+
+        <p v-if="pending" class="alert">Chargement...</p>
+        <p v-else-if="error" class="alert error">
+          Impossible de charger Supabase. Vérifiez les variables d'environnement et la table `formations`.
+        </p>
+        <p v-else-if="!formations?.length" class="alert">Aucune formation. Créez la première avec le formulaire.</p>
+
+        <div v-else class="formation-list">
+          <article v-for="formation in formations" :key="formation.id" class="formation-row">
+            <div>
+              <div class="row-title">
+                <h3>{{ formation.title }}</h3>
+                <span class="badge">{{ formation.is_published ? "Publiée" : "Brouillon" }}</span>
+              </div>
+              <p>{{ formation.description || "Sans description." }}</p>
+              <small>{{ formation.level || "Tous niveaux" }} · {{ formation.duration || "Durée libre" }}</small>
+            </div>
+            <div class="row-actions">
+              <button class="btn secondary" type="button" @click="editFormation(formation)">Modifier</button>
+              <button
+                class="btn danger"
+                type="button"
+                :disabled="deletingId === formation.id"
+                @click="removeFormation(formation)"
+              >
+                {{ deletingId === formation.id ? "Suppression..." : "Supprimer" }}
+              </button>
+            </div>
+          </article>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.admin-page {
+  max-width: 1240px;
+  margin: 0 auto;
+}
+
+.admin-heading,
+.form-header,
+.row-title,
+.row-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+}
+
+h1 {
+  margin-top: 0.5rem;
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  letter-spacing: -0.06em;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.stat-card {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.stat-card span {
+  color: var(--color-muted);
+  font-weight: 700;
+}
+
+.stat-card strong {
+  font-size: 2rem;
+}
+
+.admin-grid {
+  display: grid;
+  grid-template-columns: minmax(320px, 430px) 1fr;
+  gap: 1rem;
+  align-items: start;
+}
+
+.two-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.switch-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 700;
+}
+
+.switch-row input {
+  width: 18px;
+  height: 18px;
+}
+
+.formations-panel {
+  display: grid;
+  gap: 1rem;
+}
+
+.formation-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.formation-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+}
+
+.formation-row p {
+  color: var(--color-muted);
+  margin: 0.5rem 0;
+}
+
+.formation-row small {
+  color: var(--color-muted);
+  font-weight: 700;
+}
+
+.row-actions {
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 1080px) {
+  .admin-grid,
+  .formation-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .stats-grid,
+  .two-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-heading,
+  .form-header,
+  .row-title,
+  .row-actions {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+</style>

--- a/pages/auth.vue
+++ b/pages/auth.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+const user = useSupabaseUser()
+const { signIn, signUp, loading, errorMessage } = useAuth()
+const email = ref("")
+const password = ref("")
+const mode = ref<"login" | "signup">("login")
+const successMessage = ref("")
+
+watchEffect(() => {
+  if (user.value) {
+    navigateTo("/admin")
+  }
+})
+
+async function submit() {
+  successMessage.value = ""
+  if (!email.value || !password.value) return
+
+  const ok = mode.value === "login"
+    ? await signIn(email.value, password.value)
+    : await signUp(email.value, password.value)
+
+  if (ok && mode.value === "signup") {
+    successMessage.value = "Compte créé. Vérifiez vos emails si Supabase demande une confirmation."
+  }
+}
+</script>
+
+<template>
+  <section class="page-section">
+    <div class="container auth-grid">
+      <div class="stack">
+        <span class="badge">Espace administrateur</span>
+        <h1>Connexion au back office</h1>
+        <p>Connectez-vous pour gérer les formations visibles sur le site.</p>
+      </div>
+
+      <form class="card form-grid" @submit.prevent="submit">
+        <div class="tabs" role="tablist" aria-label="Mode d'authentification">
+          <button type="button" :class="{ active: mode === 'login' }" @click="mode = 'login'">Connexion</button>
+          <button type="button" :class="{ active: mode === 'signup' }" @click="mode = 'signup'">Créer un compte</button>
+        </div>
+
+        <p v-if="errorMessage" class="alert error">{{ errorMessage }}</p>
+        <p v-if="successMessage" class="alert success">{{ successMessage }}</p>
+
+        <label class="field">
+          <span>Email</span>
+          <input v-model="email" type="email" autocomplete="email" required>
+        </label>
+
+        <label class="field">
+          <span>Mot de passe</span>
+          <input v-model="password" type="password" autocomplete="current-password" minlength="6" required>
+        </label>
+
+        <button class="btn" type="submit" :disabled="loading">
+          {{ loading ? "Chargement..." : mode === "login" ? "Se connecter" : "Créer le compte" }}
+        </button>
+      </form>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.auth-grid {
+  display: grid;
+  grid-template-columns: 1fr minmax(300px, 460px);
+  gap: 2rem;
+  align-items: start;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4rem);
+  letter-spacing: -0.06em;
+}
+
+p {
+  color: var(--color-muted);
+}
+
+.tabs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  padding: 0.25rem;
+  border-radius: 999px;
+  background: #f1f5f9;
+}
+
+.tabs button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.7rem;
+  background: transparent;
+  color: var(--color-muted);
+  font-weight: 700;
+}
+
+.tabs button.active {
+  background: white;
+  color: var(--color-primary-dark);
+  box-shadow: 0 8px 20px rgb(15 23 42 / 8%);
+}
+
+@media (max-width: 860px) {
+  .auth-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/pages/formations.vue
+++ b/pages/formations.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+const { listFormations } = useFormations()
+const { data: formations, pending, error, refresh } = await useAsyncData(
+  "published-formations",
+  () => listFormations({ onlyPublished: true }),
+)
+</script>
+
+<template>
+  <section class="page-section">
+    <div class="container stack">
+      <div class="page-heading">
+        <div>
+          <span class="badge">Catalogue</span>
+          <h1>Formations disponibles</h1>
+        </div>
+        <button class="btn secondary" type="button" @click="refresh">Actualiser</button>
+      </div>
+
+      <p v-if="pending" class="alert">Chargement des formations...</p>
+      <p v-else-if="error" class="alert error">
+        Impossible de charger les formations. Vérifiez la table Supabase `formations`.
+      </p>
+      <div v-else-if="formations?.length" class="formations-grid">
+        <FormationCard v-for="formation in formations" :key="formation.id" :formation="formation" />
+      </div>
+      <p v-else class="alert">Aucune formation publiée pour le moment.</p>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.page-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+h1 {
+  margin: 0.6rem 0 0;
+  font-size: clamp(2rem, 5vw, 4rem);
+  letter-spacing: -0.06em;
+}
+
+.formations-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+</style>

--- a/pages/formations/[id].vue
+++ b/pages/formations/[id].vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+const route = useRoute()
+const { getFormation } = useFormations()
+
+const { data: formation, pending, error } = await useAsyncData(
+  `formation-${route.params.id}`,
+  () => getFormation(route.params.id as string),
+)
+</script>
+
+<template>
+  <section class="page-section">
+    <div class="container">
+      <NuxtLink class="back-link" to="/formations">← Retour aux formations</NuxtLink>
+
+      <p v-if="pending" class="alert">Chargement...</p>
+      <p v-else-if="error || !formation" class="alert error">Formation introuvable.</p>
+      <article v-else class="card detail-card">
+        <span class="badge">{{ formation.level || "Tous niveaux" }}</span>
+        <h1>{{ formation.title }}</h1>
+        <p class="description">{{ formation.description || "Description bientôt disponible." }}</p>
+        <dl>
+          <div>
+            <dt>Durée</dt>
+            <dd>{{ formation.duration || "À la demande" }}</dd>
+          </div>
+          <div>
+            <dt>Statut</dt>
+            <dd>{{ formation.is_published ? "Publiée" : "Non publiée" }}</dd>
+          </div>
+        </dl>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.back-link {
+  display: inline-flex;
+  margin-bottom: 1rem;
+  color: var(--color-primary-dark);
+  font-weight: 700;
+}
+
+.detail-card {
+  display: grid;
+  gap: 1rem;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4rem);
+  letter-spacing: -0.06em;
+}
+
+.description {
+  color: var(--color-muted);
+  font-size: 1.1rem;
+  line-height: 1.8;
+}
+
+dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+dt {
+  color: var(--color-muted);
+  font-weight: 700;
+}
+
+dd {
+  margin: 0.25rem 0 0;
+  font-weight: 800;
+}
+</style>

--- a/pages/formations/create.vue
+++ b/pages/formations/create.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+definePageMeta({ middleware: "auth" })
+await navigateTo("/admin")
+</script>
+
+<template>
+  <div />
+</template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,20 +1,81 @@
-<script setup>
+<script setup lang="ts">
 const user = useSupabaseUser()
 </script>
 
 <template>
-  <div>
-    <h1>🚀 Nuxt 3 + Supabase Starter</h1>
-    <p v-if="user">Bonjour, {{ user.email }}</p>
-    <p v-else>Bienvenue, connecte-toi pour accéder aux formations</p>
-
-    <nav>
-      <ul>
-        <li><NuxtLink to="/auth">Auth</NuxtLink></li>
-        <li v-if="user"><NuxtLink to="/formations">Formations</NuxtLink></li>
-        <li v-if="user"><NuxtLink to="/upload">Upload</NuxtLink></li>
-        <li v-if="user"><NuxtLink to="/admin">Admin</NuxtLink></li>
-      </ul>
-    </nav>
-  </div>
+  <section class="hero page-section">
+    <div class="container hero-grid">
+      <div class="stack">
+        <span class="badge">Formations IA pour entrepreneurs</span>
+        <h1>Créez, pilotez et vendez vos formations IA avec MS IA Academy.</h1>
+        <p>
+          Une plateforme claire pour présenter les programmes, connecter les administrateurs
+          et gérer les contenus depuis un back office sécurisé.
+        </p>
+        <div class="actions">
+          <NuxtLink class="btn" to="/formations">Découvrir les formations</NuxtLink>
+          <NuxtLink class="btn secondary" :to="user ? '/admin' : '/auth'">
+            {{ user ? "Ouvrir le back office" : "Se connecter" }}
+          </NuxtLink>
+        </div>
+      </div>
+      <div class="card hero-card">
+        <h2>Back office prêt</h2>
+        <ul>
+          <li>Connexion Supabase</li>
+          <li>Création et édition des formations</li>
+          <li>Publication / dépublication</li>
+          <li>Suppression sécurisée</li>
+        </ul>
+      </div>
+    </div>
+  </section>
 </template>
+
+<style scoped>
+.hero {
+  background:
+    radial-gradient(circle at 20% 20%, rgb(124 58 237 / 18%), transparent 30%),
+    radial-gradient(circle at 80% 10%, rgb(236 72 153 / 16%), transparent 28%);
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+  align-items: center;
+  gap: 2rem;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.3rem, 6vw, 5rem);
+  line-height: 0.95;
+  letter-spacing: -0.07em;
+}
+
+p {
+  max-width: 680px;
+  color: var(--color-muted);
+  font-size: 1.15rem;
+  line-height: 1.7;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.hero-card ul {
+  margin: 1rem 0 0;
+  padding-left: 1.2rem;
+  color: var(--color-muted);
+  line-height: 1.9;
+}
+
+@media (max-width: 860px) {
+  .hero-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/pages/upload.vue
+++ b/pages/upload.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+definePageMeta({ middleware: "auth" })
+</script>
+
+<template>
+  <section class="page-section">
+    <div class="container stack">
+      <h1>Upload</h1>
+      <FileUploader />
+    </div>
+  </section>
+</template>

--- a/supabase/formations.sql
+++ b/supabase/formations.sql
@@ -1,0 +1,41 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists public.formations (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  description text,
+  level text,
+  duration text,
+  is_published boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists formations_set_updated_at on public.formations;
+create trigger formations_set_updated_at
+before update on public.formations
+for each row execute function public.set_updated_at();
+
+alter table public.formations enable row level security;
+
+drop policy if exists "Published formations are readable" on public.formations;
+create policy "Published formations are readable"
+on public.formations for select
+using (is_published = true or auth.role() = 'authenticated');
+
+drop policy if exists "Authenticated users can manage formations" on public.formations;
+create policy "Authenticated users can manage formations"
+on public.formations for all
+to authenticated
+using (true)
+with check (true);


### PR DESCRIPTION
### Motivation
- Replace the placeholder starter UI with a proper Nuxt app shell and pages to host the public site and an authenticated back office.  
- Integrate Supabase for authentication and data so administrators can create, edit, publish and delete formations.  
- Remove leftover starter/third‑party banner content and provide a minimal global style system for the site.  

### Description
- Replaced the app entry with a Nuxt layout wrapper in `app/app.vue` and added global CSS at `assets/css/main.css`.  
- Added reusable components: `components/Footer.vue`, `components/Navbar.vue`, `components/FileUploader.vue`, and `components/FormationCard.vue`.  
- Implemented auth and data composables: `composables/useAuth.ts` (signIn/signUp/signOut) and `composables/useFormations.ts` (CRUD via Supabase).  
- Added layouts `layouts/default.vue` and `layouts/admin.vue`, protected middleware `middleware/auth.ts`, and admin UI at `pages/admin.vue` for listing, creating, editing, publishing and deleting formations (with delete confirmation).  
- Created public pages: `pages/index.vue`, `pages/auth.vue`, `pages/formations.vue`, `pages/formations/[id].vue`, `pages/upload.vue`, and a redirecting `pages/formations/create.vue`.  
- Updated `nuxt.config.ts` to include `@nuxtjs/supabase`, public runtime config helpers, and the global CSS.  
- Added Supabase SQL schema and RLS policies at `supabase/formations.sql` (table, trigger to set `updated_at`, and policies for read/manage).  
- Small UX/CSS adjustments and a confirmation prompt before deletion in `pages/admin.vue`.  

### Testing
- Ran repository checks: `git diff --check ...` for modified files (succeeded).  
- Searched for the Astro banner string with ripgrep and confirmed none remain: `rg -n "astro\.build/blog/astro-5120|Astro v5\.12 is now available"` (no matches).  
- Attempted `npm run build`, but the build is blocked by a missing optional native binding `@oxc-parser/binding-linux-x64-gnu`; `npm install` could not recover it because the environment/proxy returns `403 Forbidden`, so automated build validation failed.  
- All changes were committed: commit message `Create Supabase back office`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06daf582b4832ea19282fa9f93007c)